### PR TITLE
Ensure checkDocs fails on any error

### DIFF
--- a/.travis.d/checkDocs.sh
+++ b/.travis.d/checkDocs.sh
@@ -1,9 +1,11 @@
+#!/bin/bash
+
 sudo apt-get install graphviz;
 cd docs;
 # need to have this folder in the PYTHONPATH so we can find diracdoctools
 export PYTHONPATH=$PWD:$PYTHONPATH
 
-SPHINXOPTS=-wsphinxWarnings make htmlall
+SPHINXOPTS=-wsphinxWarnings make htmlall || { echo "Failed to build documentation, check for errors above" ; exit 1; }
 
 # check for :param / :return in html, points to faulty syntax, missing empty lines, etc.
 grep --color -nH -e :param -e :return -r build/html/CodeDocumentation/ >> sphinxWarnings


### PR DESCRIPTION
This just ensures that errors from make htmlall also make the check fail (which should happen here because of the one rst file that was not removed)